### PR TITLE
Add centrally managed packages option for C# init

### DIFF
--- a/src/Configurator/Commands/CsharpCommand/InitCsharpCommand/CsharpInitCommand.cs
+++ b/src/Configurator/Commands/CsharpCommand/InitCsharpCommand/CsharpInitCommand.cs
@@ -50,6 +50,15 @@ public class CSharpInitCommand : CliCommand
             }
         );
 
+        Options.Add(
+            new CliOption<bool>("--enable-centrally-managed-packages")
+            {
+                Description = "Whether to enable centrally managed packages.",
+                Required = false,
+                DefaultValueFactory = (defaultValue) => false
+            }
+        );
+
         CliOption<string> lspOption = new("--csharp-lsp")
         {
             Description = "The C# language server to use.",

--- a/src/Configurator/Commands/CsharpCommand/InitCsharpCommand/CsharpInitCommandAction.cs
+++ b/src/Configurator/Commands/CsharpCommand/InitCsharpCommand/CsharpInitCommandAction.cs
@@ -43,6 +43,11 @@ public class CSharpInitCommandAction : AsynchronousCliAction
                 await DotnetOperations.AddNugetConfigAsync(options.OutputDirectory);
             }
 
+            if (options.EnableCentrallyManagedPackages)
+            {
+                TemplatesOperations.CopyCsharpPackagesPropsTemplate(options.OutputDirectory);
+            }
+
             if (options.AddGitVersion)
             {
                 ConsoleUtils.WriteInfo("\n🚀 GitVersion");

--- a/src/Configurator/External/Templates/CSharp/CopyCsharpPackagesPropsTemplate.cs
+++ b/src/Configurator/External/Templates/CSharp/CopyCsharpPackagesPropsTemplate.cs
@@ -1,0 +1,60 @@
+using SmallsOnline.VSCode.Configurator.Utilities;
+
+namespace SmallsOnline.VSCode.Configurator.External;
+
+public partial class TemplatesOperations
+{
+    /// <summary>
+    /// Copies the 'Directory.Packages.props' file to the project root.
+    /// </summary>
+    /// <param name="outputDirectory">The output directory for the new project.</param>
+    public static void CopyCsharpPackagesPropsTemplate(string outputDirectory)
+    {string templateFilesPath = Path.Combine(
+            _coreTemplatesPath,
+            "Templates",
+            "csharp",
+            "PropsFiles"
+        );
+
+        string directoryPackagesPropsTemplatePath = Path.Combine(
+            templateFilesPath,
+            "Directory.Packages.props"
+        );
+
+        string directoryPackagesPropsOutputPath = Path.Combine(
+            outputDirectory,
+            "Directory.Packages.props"
+        );
+
+        ConsoleUtils.WriteInfo($"- 📄 Copying 'Directory.Packages.props' to project root... ", false);
+
+        if (File.Exists(directoryPackagesPropsOutputPath))
+        {
+            if (ConsoleUtils.PromptToOverwriteFile())
+            {
+                File.Delete(directoryPackagesPropsOutputPath);
+            }
+            else
+            {
+                ConsoleUtils.WriteWarning("Already exists. 🟠\n", false);
+                return;
+            }
+        }
+
+        try
+        {
+            File.Copy(
+                sourceFileName: directoryPackagesPropsTemplatePath,
+                destFileName: directoryPackagesPropsOutputPath,
+                overwrite: true
+            );
+        }
+        catch (Exception)
+        {
+            ConsoleUtils.WriteError("Failed. ❌\n", false);
+            throw;
+        }
+
+        ConsoleUtils.WriteSuccess("Done. ✅\n", false);
+    }
+}

--- a/src/Configurator/Models/Commands/CsharpInitCommandCliOptions.cs
+++ b/src/Configurator/Models/Commands/CsharpInitCommandCliOptions.cs
@@ -18,6 +18,7 @@ public class CSharpInitCommandCliOptions
         SolutionName = ParseSolutionNameArgument(parseResult);
         AddGitVersion = ParseAddGitVersionArgument(parseResult);
         AddNugetConfig = ParseAddNugetConfigArgument(parseResult);
+        EnableCentrallyManagedPackages = ParseEnableCentrallyManagedPackagesArgument(parseResult);
         CsharpLsp = ParseCsharpLspOption(parseResult);
     }
 
@@ -41,6 +42,14 @@ public class CSharpInitCommandCliOptions
     /// </summary>
     public bool AddNugetConfig { get; set; }
 
+    /// <summary>
+    /// Whether to enable centrally managed packages.
+    /// </summary>
+    public bool EnableCentrallyManagedPackages { get; set; }
+
+    /// <summary>
+    /// The LSP to use for C#.
+    /// </summary>
     public CsharpLspOption CsharpLsp { get; set; }
 
     /// <summary>
@@ -99,6 +108,16 @@ public class CSharpInitCommandCliOptions
     private static bool ParseAddNugetConfigArgument(ParseResult parseResult)
     {
         return parseResult.GetValue<bool>("--add-nuget-config");
+    }
+
+    /// <summary>
+    /// Parse the '--enable-centrally-managed-packages' argument from the command line.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <returns>Whether to enable centrally managed packages.</returns>
+    private static bool ParseEnableCentrallyManagedPackagesArgument(ParseResult parseResult)
+    {
+        return parseResult.GetValue<bool>("--enable-centrally-managed-packages");
     }
 
     /// <summary>

--- a/src/Configurator/Templates/csharp/PropsFiles/Directory.Packages.props
+++ b/src/Configurator/Templates/csharp/PropsFiles/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Description

* Adds the ability to use `--enable-centrally-managed-packages` when running `csharp init`.

### Type of change

- [x] 🌟 New feature
- [ ] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None