### PR TITLE
Update GitVersion.yml template for GitVersion v6.0.0

### DIFF
--- a/src/Configurator/Templates/csharp/GitVersion/GitVersion.yml
+++ b/src/Configurator/Templates/csharp/GitVersion/GitVersion.yml
@@ -1,7 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatchTag
 mode: ContinuousDeployment
 increment: Inherit
-continuous-delivery-fallback-tag: 'preview'
 branches: {}
 ignore:
   sha: []


### PR DESCRIPTION
## Description

* Removes the `continuous-delivery-fallback-tag` property from the template since it's no longer available.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
